### PR TITLE
Only deploy on production on a regular build to master

### DIFF
--- a/server/heroku/heroku.sh
+++ b/server/heroku/heroku.sh
@@ -8,6 +8,11 @@ if [[ $TRAVIS_BRANCH != "master" && $TARGET_ENV == "prod" ]] ; then
     DEPLOY="false"
 fi
 
+echo "=> PR: $TRAVIS_PULL_REQUEST"
+if [[ $TRAVIS_BRANCH == "master" && $TRAVIS_PULL_REQUEST != "false" ]] ; then
+    DEPLOY="false"
+fi
+
 
 if [[ $DEPLOY == "true" ]] ; then
     if [ -z $BUILD_DIR -a -z $CI_HOME -a -z $TARGET_ENV ] ; then


### PR DESCRIPTION
This commit makes sure that builds for PRs on master are not yet
deployed. First these builds can be used to test the PR, for the actual
deployment the merge of the PR must have take place before.
